### PR TITLE
Patch brew bundle: mas get instead of mas install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ devenv.local.yaml
 
 # pre-commit
 .pre-commit-config.yaml
+
+# If we try to build this system with nix
+result

--- a/.install.sh
+++ b/.install.sh
@@ -49,45 +49,12 @@ if [ ! -x /opt/homebrew/bin/brew ]; then
   NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi
 
-# Install mas to manage App Store apps
-if [ ! -x /opt/homebrew/bin/mas ]; then
-  /opt/homebrew/bin/brew install mas
-fi
-
 # Sign into App Store before nix-darwin (needed for mas app installs)
-if [ -d "/Applications/Amphetamine.app" ]; then
-  echo "App Store already verified (Amphetamine installed). Skipping..."
-else
-  echo ""
-  echo "=== App Store Setup ==="
-  echo "1. Open App Store and sign in with your Apple ID"
-  echo "2. When prompted, click 'Always Allow' to approve installs"
-  echo ""
-  echo "Press Enter when you have signed in..."
-  read -r
-
-  # Install a small free app to trigger the approval dialog
-  echo "Installing Amphetamine to verify App Store access..."
-  MAS_NO_AUTO_INDEX=1 /opt/homebrew/bin/mas get 937984704 || true
-
-  # Wait for the app to appear in /Applications
-  echo "Waiting for Amphetamine to install..."
-  timeout=120
-  elapsed=0
-  while [ ! -d "/Applications/Amphetamine.app" ] && [ $elapsed -lt $timeout ]; do
-    sleep 2
-    elapsed=$((elapsed + 2))
-  done
-
-  if [ -d "/Applications/Amphetamine.app" ]; then
-    echo "App Store working! Continuing..."
-  else
-    echo "WARNING: Amphetamine did not appear in /Applications after ${timeout}s"
-    echo "App Store installs may fail. You can re-run this script later."
-    echo "Press Enter to continue anyway or Ctrl+C to abort..."
-    read -r
-  fi
-fi
+echo ""
+echo "=== App Store Setup ==="
+echo "Open App Store and sign in with your Apple ID before continuing."
+echo "Press Enter when you have signed in..."
+read -r
 
 # Setup MacOS with nix
 sudo nix run nix-darwin/master#darwin-rebuild -- switch --flake ~/.dotfiles/

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -2,7 +2,7 @@ keys:
   # Main age key for this macbook
   - &user_onnimonni age1se1q2r6sc647nl3zp5cenuqclgj0e9czw43hq2y3amfyhv5yrnc326fusl30yv
   - &host_macbook_pro age1mv0fkqmh7tju54cgv05wvzn28p8zp4nfcx9yamu37w8hqcmqs3rs3l7mrv
-  - &server age1se1q27dr0un75pcgxkjdcgzv0nyx9z7cwc860hjxs4eum5fv7zvxkz36a6wwh0
+  - &server age1se1qfptarnwfn4adk9n565afaejj8ghm2u7wyhzxe7dj7w8spu28wnuytaruzg
 
 creation_rules:
   # All secrets in the secrets directory can be decrypted with the user key

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -2,6 +2,7 @@ keys:
   # Main age key for this macbook
   - &user_onnimonni age1se1q2r6sc647nl3zp5cenuqclgj0e9czw43hq2y3amfyhv5yrnc326fusl30yv
   - &host_macbook_pro age1mv0fkqmh7tju54cgv05wvzn28p8zp4nfcx9yamu37w8hqcmqs3rs3l7mrv
+  - &server age1se1q27dr0un75pcgxkjdcgzv0nyx9z7cwc860hjxs4eum5fv7zvxkz36a6wwh0
 
 creation_rules:
   # All secrets in the secrets directory can be decrypted with the user key
@@ -10,3 +11,4 @@ creation_rules:
     - age:
       - *user_onnimonni
       - *host_macbook_pro
+      - *server

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,192 @@
+IMPORTANT: In all interactions and commit messages, be extremely concise and sacrifice grammar for the sake of concision.
+
+My name is Onni Hakala and my nickname is onnimonni. Use onni@flaky.build in emails.
+
+## GitHub
+
+- Your primary method for interacting with GitHub should be the GitHub CLI (gh).
+
+### Viewing private issue attachments
+To view attachments from private repository issues:
+
+```sh
+gh api -H "Accept: application/octet-stream" \
+  "https://github.com/user-attachments/assets/32c11c1a-3afb-48ec-8fb6-9d95ed8d4d96" > /tmp/issue-53.png 2>&1
+```
+
+## Use Githits and context7 MCP servers
+Instead of using 'Web Search' skill, prefer using the Githits and context7 MCP servers for fetching up-to-date information.
+
+These can provide help when you want to find code examples and libraries and function documentation.
+
+## Documentation files
+
+Keep existing README.md updated when making relevant changes. Never create new markdown/doc files unless user explicitly asks.
+
+## Plans
+
+- At the end of each plan, give me a list of unresolved questions to answer, if any. Make the questions extremely concise. Sacrifice grammar for the sake of concision.
+
+## Avoid calling system shells from the code
+
+NEVER EVER use `popen` or `system()` or `shell()` or similiar methods for running commands from other coding language.
+If problem can't be solved in other ways you need to inform the user about it.
+Using binaries in $PATH is only allowed in bash scripts but not in other programming languages.
+
+## Use env in shell scripts
+
+Shell scripts should start like this:
+```
+#!/usr/bin/env bash
+```
+
+## Using environmental variables with make
+
+env like `GEN=ninja` need to be used after the make command, not before it:
+
+```sh
+make release GEN=ninja VCPKG_TOOLCHAIN_PATH=$(pwd)/vcpkg/scripts/buildsystems/vcpkg.cmake
+```
+
+## System clock
+
+Don't trust your memory; you cannot remember time accurately.
+If you need to get the current time use:
+
+```sh
+date
+```
+
+## DuckDB
+
+You can enable timer by running `.timer on` command in duckdb sql script.
+
+### Printing messages
+You can't print in duckdb scripts. This doesn't work:
+
+```sql
+.echo Done!
+```
+
+Instead you need to:
+
+```sql
+SELECT "Done!" as status
+```
+
+## Duckdb CLI file flag
+If you want to run SQL files with duckdb CLI use:
+
+```sh
+duckdb -f myscript.sql
+```
+
+### Querying JSON/structured data in varchar columns
+NEVER use LIKE to query varchar columns containing JSON or structured data. Parse it properly:
+
+```sql
+-- BAD: Using LIKE to find JSON values
+SELECT * FROM table WHERE data LIKE '%"key": "value"%';
+
+-- GOOD: Parse JSON and query properly
+SELECT * FROM table WHERE json_extract_string(data, '$.key') = 'value';
+```
+
+If proper parsing tools/extensions aren't available, tell user to build/find them rather than using LIKE.
+
+## Failing git commit
+
+**IMPORTANT: You are never allowed to use `--no-verify` in git commits**
+
+Git commit hooks verify that code is linted and tested and that they don't contain secrets.
+
+Fix the pre-commit hook issues instead of bypassing them.
+
+**Always use `--no-gpg-sign` flag in git commits** to skip GPG signing.
+
+Ask input from user if you get blocked and never use `--no-verify` unless when explicitly allowed by the user!
+
+You are not allowed to use SKIP variable before git commit to skip hooks:
+```
+SKIP=... git commit -m "..."
+```
+
+## Pushing git
+
+Do not push git commits unless when user allowed it.
+
+Use `git push origin HEAD` instead of just `git push` to avoid pushing all local branches.
+
+## Failing github actions
+
+If github actions fail for a temporary issues don't create custom overlays.
+Instead rerun them first to see if it would fix them:
+
+```sh
+gh run rerun <id>
+```
+
+## Adding custom tools, dependencies or git hooks
+
+If project needs tools which are not yet installed ensure that `devenv.nix` exists in the project.
+
+If it doesn't exist you need to run: `devenv init` first.
+
+Then add the required tools or git hooks to `devenv.nix`.
+
+## Installing git hooks
+
+Always install git hooks into the devenv.nix
+
+## Use sd instead of sed
+Use `sd` for find & replace instead of `sed`. It's simpler and more intuitive:
+
+```sh
+# sed: confusing syntax with -i, escaping, delimiters
+sed -i 's/before/after/g' file.txt
+
+# sd: simple and intuitive
+sd 'before' 'after' file.txt
+```
+
+sd uses regex by default. For literal strings use `-F`:
+```sh
+sd -F 'literal.string' 'replacement' file.txt
+```
+
+## Cargo documents
+Do not use `--open` flag with `cargo doc`
+
+## Rust Build Performance
+
+- **Use `cargo check`** for 90% of dev work (skips codegen/linking, 10x faster)
+- **Never use full `lto = true`** in release - use `lto = "thin"` instead (20-30% faster builds)
+- **Strip debug from deps** in `.cargo/config.toml`:
+  ```toml
+  [profile.dev.package."*"]
+  debug = false
+  strip = true
+  ```
+- Monitor target/ size - if >5GB, run cargo clean (stale artifacts accumulate)
+- Use lld linker on Linux for 2-5x faster linking (add to devenv.nix)
+- macOS: ld64 is already fast, don't configure custom linker
+
+## Prefer libraries to fix html entities and encoding issues
+This is terrible (manual replacements):
+```rust
+let unescaped = trimmed
+    .replace("&lt;", "<")
+    .replace("&gt;", ">")
+    .replace("&quot;", "\"")
+    .replace("&amp;", "&")
+    .replace("&#39;", "'")
+    .replace("&apos;", "'");
+```
+
+This is great (using htmlescape library):
+```rust
+let unescaped = match htmlescape::decode_html(trimmed) {
+    Ok(decoded) => decoded,
+    Err(_) => trimmed.to_string(),
+};
+```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ xcode-select --install
 git clone https://github.com/onnimonni/dotfiles ~/.dotfiles
 
 ~/.dotfiles/.install.sh
+
+# Then create age key with secure enclave
+mkdir -p ~/.config/sops/age/
+age-plugin-se keygen --access-control none -o ~/.config/sops/age/secure-enclave-key.txt
 ```
 
 ## Using this config with your own user
@@ -91,6 +95,9 @@ launchctl kickstart -k gui/$(id -u)/org.pqrs.service.agent.karabiner_console_use
 
 ## Docs for common procedures
 * [Using Estonian ID-card as ssh public key](docs/estonian-id-card.md)
+
+## MCP
+Githits and context7 MCP are configured for Claude and Codex via nix-darwin modules.
 
 ## UNLICENSE
 Use these dotfiles as you want to. Sharing is caring!

--- a/darwin/system/agents.nix
+++ b/darwin/system/agents.nix
@@ -33,6 +33,10 @@
 
         These can provide help when you want to find code examples and libraries and function documentation.
 
+        ## Documentation files
+
+        Keep existing README.md updated when making relevant changes. Never create new markdown/doc files unless user explicitly asks.
+
         ## Plans
 
         - At the end of each plan, give me a list of unresolved questions to answer, if any. Make the questions extremely concise. Sacrifice grammar for the sake of concision.

--- a/darwin/system/default.nix
+++ b/darwin/system/default.nix
@@ -10,6 +10,7 @@
     ./claude.nix
     ./gemini.nix
     ./agents.nix
+    ./mcp.nix
   ];
 
   # Pretty nice examples for setting up nix-darwin: https://github.com/thurstonsand/nixonomicon

--- a/darwin/system/mcp.nix
+++ b/darwin/system/mcp.nix
@@ -1,0 +1,24 @@
+{
+  config,
+  pkgs,
+  lib,
+  username,
+  ...
+}:
+{
+  # Home-manager configuration for mcp
+  home-manager.users.${username} = {
+    home.file = {
+      ".mcp.json".text = ''
+        {
+          "servers": {
+            "GitHits": {
+              "url": "https://mcp.githits.com",
+              "type": "http"
+            }
+          }
+        }
+      '';
+    };
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768530555,
-        "narHash": "sha256-EBXKDho4t1YSgodAL6C8M3UTm8MGMZNQ9rQnceR5+6c=",
+        "lastModified": 1771037579,
+        "narHash": "sha256-NX5XuhGcsmk0oEII2PEtMRgvh2KaAv3/WWQsOpxAgR4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d21bee5abf9fb4a42b2fa7728bf671f8bb246ba6",
+        "rev": "05e6dc0f6ed936f918cb6f0f21f1dad1e4c53150",
         "type": "github"
       },
       "original": {
@@ -27,27 +27,26 @@
         ]
       },
       "locked": {
-        "lastModified": 1770888310,
-        "narHash": "sha256-RMa8JyavvKEWrJvhV9W1WM6hWUkZeeKFhzdhnlaOVCI=",
-        "owner": "onnimonni",
+        "lastModified": 1770922915,
+        "narHash": "sha256-6J/JoK9iL7sHvKJcGW2KId2agaKv1OGypsa7kN+ZBD4=",
+        "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "8367403bdd1f1448d751be4a8fc02a8ef77ef470",
+        "rev": "6c5a56295d2a24e43bcd8af838def1b9a95746b2",
         "type": "github"
       },
       "original": {
-        "owner": "onnimonni",
-        "ref": "fix/mas-user-session",
+        "owner": "nix-darwin",
         "repo": "nix-darwin",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768305791,
-        "narHash": "sha256-AIdl6WAn9aymeaH/NvBj0H9qM+XuAuYbGMZaP0zcXAQ=",
+        "lastModified": 1771008912,
+        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1412caf7bf9e660f2f962917c14b1ea1c3bc695e",
+        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
         "type": "github"
       },
       "original": {
@@ -72,11 +71,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768481291,
-        "narHash": "sha256-NjKtkJraCZEnLHAJxLTI+BfdU//9coAz9p5TqveZwPU=",
+        "lastModified": 1770683991,
+        "narHash": "sha256-xVfPvXDf9QN3Eh9dV+Lw6IkWG42KSuQ1u2260HKvpnc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "e085e303dfcce21adcb5fec535d65aacb066f101",
+        "rev": "8b89f44c2cc4581e402111d928869fe7ba9f7033",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,9 +9,7 @@
     #determinate.url = "https://flakehub.com/f/DeterminateSystems/determinate/0.1";
 
     nix-darwin = {
-      # Use fork with fix for mas App Store auth in user's GUI session
-      # PR: https://github.com/nix-darwin/nix-darwin/issues/1694
-      url = "github:onnimonni/nix-darwin/fix/mas-user-session";
+      url = "github:nix-darwin/nix-darwin";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     home-manager = {

--- a/secrets/secrets.yaml
+++ b/secrets/secrets.yaml
@@ -1,18 +1,38 @@
-#ENC[AES256_GCM,data:IFE0lTc/6F+Go5Lfyvx81Siqcsj2ZH+K,iv:4fjwDWv+abqd2RAfSi5s+0eMTuU/FUKLosqwiPgncys=,tag:bY0b+JnezhgB5QDXfP/Wjw==,type:comment]
-githits_api_key: ENC[AES256_GCM,data:EgC9dQ0IAFbgQHfk7tNKhRDsBrsTfo7XhKCf49DIrOpAUaMDhw0c2vwJ/wlz5Ls=,iv:yQc1QjWwSa1+A9gBF2ai7+oIioWMKnQOuPpWX/fHGuI=,tag:voyqjPKn5LKS2iNdpJRHGA==,type:str]
-context7_api_key: ENC[AES256_GCM,data:asJDOO0PDxq35xaO1ezepskjZiFMde0rKf+DYkGMhb9Xo/o+Q4xanTe6Nw==,iv:l7zx9+I/XnGFUzsuS73YzcMyek1Bno/KSF9M8aGyfiM=,tag:kHMWO30gvv19LzQ0m60F8A==,type:str]
+#ENC[AES256_GCM,data:UrRhdTTJ9M+cb8BV1lg/e3/cP1tYNs+fmNzzBDftJDaTxQVW,iv:Qgf1phPq4kZtqNH79YEDDQQHrQq/wu7viEgnknQzfY8=,tag:LmKlZqMnO8fxKX8RfIaJTg==,type:comment]
+githits_api_key: ENC[AES256_GCM,data:yTPuWF5wYyaP2KdT3TNhLTfJMrM6Z8F8mSrxWsA7OoYvyo5Aa9nSuB3mZNO/ppc=,iv:Gx4/OGOk1oEZ8ujacO3j+ICDkjkzX98PCyvsOzrTuMs=,tag:lYlTRBN6unFf+NnUlF09Tg==,type:str]
+context7_api_key: ENC[AES256_GCM,data:FXvO8u43Z2V5JrO7sHYNKLZZAAxpbJ7TlXAj6twzoCvoCDmqjAmUFYFwzw==,iv:Nsg+nqjfonBLIr5r+/5B7Z/4R2KDIntdzyMUa8R+B3Y=,tag:q3fdKfEKRaiOIhNsUv7ezA==,type:str]
 sops:
     age:
+        - recipient: age1se1q2r6sc647nl3zp5cenuqclgj0e9czw43hq2y3amfyhv5yrnc326fusl30yv
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHBpdi1wMjU2IGRTeElzdyBBOUVkaWVk
+            WmowMEdrbWJ5YU5IaVJyRUpUNFN0UU9za21WcEdmYWVzWUJKcApSS20xc093WXBC
+            ZnZBcUhlRyt6ZUcxUzB5UFRyQU9ieXVkWXlWQjFFRUlVCi0tLSB5V2pNaUg4MWpq
+            ZjN5bTF3QXh0Y2Z3d2VudXpEOVpIUWI0TVdjYXFTOHMwCiN+eIYdjwn6FaDYORNZ
+            hHtFEZBkiQBiOp4UswzzfqPS/5hfs7fhpp+k438VR37hsJ3OhhME3A40VydcmEwe
+            yrg=
+            -----END AGE ENCRYPTED FILE-----
         - recipient: age1mv0fkqmh7tju54cgv05wvzn28p8zp4nfcx9yamu37w8hqcmqs3rs3l7mrv
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5V2FXbXlQM0w3L0FIMUw3
-            MHhQeFNOTXhQRi9TaWs1Y3BXdkFJdWloS0dzCjZzblJQNFhBNUFaZ2V6Z200S1VP
-            QWlEb0J1KzFOMFpXZmR5M1VaT2E3Q0kKLS0tIExadjIrS3NLM25CVDZoa0pJdU9x
-            MitWQXl4YU5kdlMxODRQTXVoOFNEU28KgUZzcAg1XURKt2RoEO/lCFgynk6DWs+h
-            iuFToztIBYGOi6sXFTtc66QpaM5bO5LTttZh8C/XvjEoSK8XM5MvZg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5RHNQdlhSVk53S2hOTVVE
+            UldMOW9RR1NOdlZYazFCWFV0SkUrTGlnYlRrCmhBZ1A3R1dqS1BJR0pyblBYcTRI
+            TTNNK0Jyem1kQXJKYkRxeFVUWkdhNmcKLS0tIGhZaWYyeFV0ajU2cE1Fb2xCRUxH
+            ZVBXUE83OEk5ekttK3cwM3MrejhzVUUKNdNdg7UKWDJlvti4BRr/AZnHiea/Wbv5
+            EWWa9nfZg+buig64/ytrjnhiLoIVOKBvcReJLcp9A7sQgne4/1hVyA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-01-30T18:23:31Z"
-    mac: ENC[AES256_GCM,data:0x/W1gkhypC73EIJrzlqvDCH3ue9YtgkyAWJH2y2owLaItpNAQA6YENYS8s9JGnNR+lTWclpLKCL8AfiHd3uXLGFQTo9x2w0+PLiHHnRQsDD+UhkX8FH/ARkwWKJZQL81lFYlxe/L8HbfKR3La6PUfoA1Z+DCAlSIfzIC6BtonU=,iv:4Gg1PtzEI+IvwWM6QuChOuLwnrm9UoDUK/4ZyqL9QiQ=,tag:4oeB7CaM/pmYYbg1a5M2FQ==,type:str]
+        - recipient: age1se1q27dr0un75pcgxkjdcgzv0nyx9z7cwc860hjxs4eum5fv7zvxkz36a6wwh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHBpdi1wMjU2IGExaXhrZyBBK3ZROGNP
+            QUJsRXd0cjV5dGFXTjU2cTV2TVNRenA4bFVhSGwvWXMwUHJRcQo5ZmcxUmFwTWFY
+            MSswMzU4MmNoemRZVGZUSm41WGhqQzhLZk03U0U1Z01ZCi0tLSArWjBuN2lrY1JN
+            UlpkRmU5cUxPQktOdm1MQ09nRW1YWkNGbGYrUG0wMU9RChzTQykrvXjRSzVsB3li
+            z4S73Zti7iirqN2hOkvMu6HM6xZx5ozx6g/hhKeCmIilFqF3rlgQvZkn0WYOYDN3
+            wgo=
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-02-14T17:51:37Z"
+    mac: ENC[AES256_GCM,data:Mr5Sv+JGui/l1Y9pcVtpCoEeCneQevuSU6BxyN4f1fL+T+5KAh95ACagI+LshS26g+WXyqLwsjBEJa10Bq1YcCJfyUHylaSiT2okODkw7VUNCtgCTXiH4a0uk13iYUQoVJ5Qyshug+iVLtbopjwv7zhGO6NsF3v82oBbbnOcQ0k=,iv:0ayXml1nt3Sm27BAfSDIaYegEDMd54kbc8AEpaBMogg=,tag:APXx2k6rWc/cWi3c05S5ug==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/secrets/secrets.yaml
+++ b/secrets/secrets.yaml
@@ -1,38 +1,38 @@
-#ENC[AES256_GCM,data:UrRhdTTJ9M+cb8BV1lg/e3/cP1tYNs+fmNzzBDftJDaTxQVW,iv:Qgf1phPq4kZtqNH79YEDDQQHrQq/wu7viEgnknQzfY8=,tag:LmKlZqMnO8fxKX8RfIaJTg==,type:comment]
-githits_api_key: ENC[AES256_GCM,data:yTPuWF5wYyaP2KdT3TNhLTfJMrM6Z8F8mSrxWsA7OoYvyo5Aa9nSuB3mZNO/ppc=,iv:Gx4/OGOk1oEZ8ujacO3j+ICDkjkzX98PCyvsOzrTuMs=,tag:lYlTRBN6unFf+NnUlF09Tg==,type:str]
-context7_api_key: ENC[AES256_GCM,data:FXvO8u43Z2V5JrO7sHYNKLZZAAxpbJ7TlXAj6twzoCvoCDmqjAmUFYFwzw==,iv:Nsg+nqjfonBLIr5r+/5B7Z/4R2KDIntdzyMUa8R+B3Y=,tag:q3fdKfEKRaiOIhNsUv7ezA==,type:str]
+#ENC[AES256_GCM,data:Q+zFx2uVk0AGleX4NLbCaWOZNe+IEw4dGFJAd9YLPcX+oV2p,iv:o8O0zGyKzg2q2p/Ip43wuuFiQblx1ciRd2Ga9RJRoVg=,tag:WjMVCI1U/aTmgWWVAVHJCg==,type:comment]
+githits_api_key: ENC[AES256_GCM,data:uQNcU1MuGfWPQlx3sVtQtz7MCYWOUtAIV6ImELWrnL+Cl6PY4cK8CYbTJtuciKU=,iv:Ho++rw3CBiWtPm0rIqxR8X5RKkwFHmhR459YtFmhzAw=,tag:B1MjlNbqTv1D2eo5pzcm/A==,type:str]
+context7_api_key: ENC[AES256_GCM,data:7Hbr8bgoNRFjkzsHOOSeoOC0x/HWy+lLh0dWWvyUacTWSTrNf3nSBwL9Pg==,iv:M6ABp5ViyCg+Ef1mqSWCpNvGSAgn3AD+42CRsJIrzBE=,tag:Sz4cSo5pZbAckkAu43k0cw==,type:str]
 sops:
     age:
         - recipient: age1se1q2r6sc647nl3zp5cenuqclgj0e9czw43hq2y3amfyhv5yrnc326fusl30yv
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHBpdi1wMjU2IGRTeElzdyBBOUVkaWVk
-            WmowMEdrbWJ5YU5IaVJyRUpUNFN0UU9za21WcEdmYWVzWUJKcApSS20xc093WXBC
-            ZnZBcUhlRyt6ZUcxUzB5UFRyQU9ieXVkWXlWQjFFRUlVCi0tLSB5V2pNaUg4MWpq
-            ZjN5bTF3QXh0Y2Z3d2VudXpEOVpIUWI0TVdjYXFTOHMwCiN+eIYdjwn6FaDYORNZ
-            hHtFEZBkiQBiOp4UswzzfqPS/5hfs7fhpp+k438VR37hsJ3OhhME3A40VydcmEwe
-            yrg=
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHBpdi1wMjU2IGRTeElzdyBBaDVRNnR2
+            UVc0Z2d1OXZyanVJSXRZd1NBK2c2NnN3M0ZQd0VXV0c0emxZVQpCU0VvM2ExbWZi
+            bGhBZWI5K08zL1RBVVk0bTRGMGxBSFl1RDQ5QU9XdGxjCi0tLSBrOE5KZDh6NWEv
+            eVNTYitMSUhmRE9Ubll6K3NrMDFXY0VVWXJRMnFSbmxJCsc1nJtlXMSt/NDkKBG7
+            NWMr0/vrYA4byhvVnof0JahAdWCRQG04G554wdCzBRL/+IOIU16ouzxE4/ACvugD
+            ktM=
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1mv0fkqmh7tju54cgv05wvzn28p8zp4nfcx9yamu37w8hqcmqs3rs3l7mrv
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5RHNQdlhSVk53S2hOTVVE
-            UldMOW9RR1NOdlZYazFCWFV0SkUrTGlnYlRrCmhBZ1A3R1dqS1BJR0pyblBYcTRI
-            TTNNK0Jyem1kQXJKYkRxeFVUWkdhNmcKLS0tIGhZaWYyeFV0ajU2cE1Fb2xCRUxH
-            ZVBXUE83OEk5ekttK3cwM3MrejhzVUUKNdNdg7UKWDJlvti4BRr/AZnHiea/Wbv5
-            EWWa9nfZg+buig64/ytrjnhiLoIVOKBvcReJLcp9A7sQgne4/1hVyA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4RStBUUZRK0xWRlF1S3pW
+            T1VURXJ3VlV1TDRhNzFTSW1FbDJlVm1jY25VCmtzSWRFZGtCSGNuV1dlQ29WVk1o
+            TzRWcDV0NTNUM1E4SDZvR2lKdEdyWjAKLS0tIGsveWJGL2pTcVRLVHliNEdDaTRs
+            V25QSEpxbktnZUxFTXZ5cjZJVzNxeG8KaiRb6E0xGO/TqZK3ry/cRDMfP3b6VecX
+            H1Ul86BTNRU1TEOqRhwD7s4C0PL9Yy1uJo5zd03bWDnC/5yQivTmKg==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1se1q27dr0un75pcgxkjdcgzv0nyx9z7cwc860hjxs4eum5fv7zvxkz36a6wwh0
+        - recipient: age1se1qfptarnwfn4adk9n565afaejj8ghm2u7wyhzxe7dj7w8spu28wnuytaruzg
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHBpdi1wMjU2IGExaXhrZyBBK3ZROGNP
-            QUJsRXd0cjV5dGFXTjU2cTV2TVNRenA4bFVhSGwvWXMwUHJRcQo5ZmcxUmFwTWFY
-            MSswMzU4MmNoemRZVGZUSm41WGhqQzhLZk03U0U1Z01ZCi0tLSArWjBuN2lrY1JN
-            UlpkRmU5cUxPQktOdm1MQ09nRW1YWkNGbGYrUG0wMU9RChzTQykrvXjRSzVsB3li
-            z4S73Zti7iirqN2hOkvMu6HM6xZx5ozx6g/hhKeCmIilFqF3rlgQvZkn0WYOYDN3
-            wgo=
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHBpdi1wMjU2IEtmUWlpUSBBOURsYTJP
+            QkFNb3FsZkhGZThzajNmNlVnbElmMjRiR3RpbzB4dHNqVTlSMAoyZCt6N0VTVGxO
+            aU1HdlF5UUtiTUhVYjUvYk1iRnQ5bVUycnd4ZDcvMkljCi0tLSBRbmd2VmhMNmVB
+            aDREUUpnSG9TZXZPL2lnY0g4Um1WYlFmYlVWbVF5SW1jCr54wYduMg7wSKq9Tz3c
+            ZUKOO/UYUjahK5oUdARZeV64B4cGykA+kRhb1FgXvydLNTcypAyJd2IX+x4daYLG
+            KFI=
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-02-14T17:51:37Z"
-    mac: ENC[AES256_GCM,data:Mr5Sv+JGui/l1Y9pcVtpCoEeCneQevuSU6BxyN4f1fL+T+5KAh95ACagI+LshS26g+WXyqLwsjBEJa10Bq1YcCJfyUHylaSiT2okODkw7VUNCtgCTXiH4a0uk13iYUQoVJ5Qyshug+iVLtbopjwv7zhGO6NsF3v82oBbbnOcQ0k=,iv:0ayXml1nt3Sm27BAfSDIaYegEDMd54kbc8AEpaBMogg=,tag:APXx2k6rWc/cWi3c05S5ug==,type:str]
+    lastmodified: "2026-02-14T18:47:04Z"
+    mac: ENC[AES256_GCM,data:cZHJk5PYyake9eljYSfazTK7VgIwuNgdS2IZee5Ate2hGDNZnoaGnJbty/FhoeMgAT1UajxKURZktReF93CpvGlraUFqsaMeC89nsQEF5SEL1/poR0CtT5vo6Nen7s+wZxP+2scpTVvpcN0t7rqL0fCs6hyRQjphFuTxORWTcv0=,iv:/JRi80bQoxC/axwipvrkyJ5gFj7KJqb5gux2fPCVlck=,tag:FWSlJ6um0ikFGOSpCAXaUg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0


### PR DESCRIPTION
## Summary
- Patch `mac_app_store_installer.rb` in preActivation to use `mas get` instead of `mas install`
- Fixes fresh Apple Accounts failing with "Redownload Unavailable" during `brew bundle`
- Idempotent: only patches if the old string is present

Upstream: https://github.com/Homebrew/brew/issues/21559
Brew fork PR: https://github.com/onnimonni/brew/pull/1

## Test plan
- [ ] `darwin-rebuild switch --flake ~/.dotfiles/` on fresh Apple Account machine
- [ ] Verify masApps install without manual `mas get` workaround
- [ ] Remove this patch once upstream merges the fix